### PR TITLE
Rename cs-CZ.yml to cs.yml

### DIFF
--- a/locales/cs.yml
+++ b/locales/cs.yml
@@ -1,4 +1,4 @@
-cs-CZ:
+cs:
   admin:
     actions:
       bulk_delete:


### PR DESCRIPTION
Change to global default shortcut of Czech language.