### PR TITLE
Change "Adicionar" for "Añadir"

### DIFF
--- a/locales/es.yml
+++ b/locales/es.yml
@@ -44,8 +44,8 @@ es:
       new:
         breadcrumb: Nuevo
         done: creado
-        link: Adicionar un nuevo  %{model_label}
-        menu: Adicionar Nuevo
+        link: Añadir un nuevo %{model_label}
+        menu: Añadir Nuevo
         title: Nuevo  %{model_label}
       show:
         breadcrumb: "%{object_label}"


### PR DESCRIPTION
Hey,

Thanks for this great gem. I noticed that this translation file mixes "Adicionar" and "Añadir" for "Add". The correct term is "Añadir", so I've changed the other two instances of "Adicionar" for it.