### PR TITLE
Fixed RU translation for `all_of_the_following_related_items_will_be_deleted` key

### DIFF
--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -122,7 +122,7 @@ ru:
       save: "Сохранить"
       save_and_add_another: "Сохранить и добавить новый"
       save_and_edit: "Сохранить и продолжить редактирование"
-      all_of_the_following_related_items_will_be_deleted: "Следующие объекты будут удалены:"
+      all_of_the_following_related_items_will_be_deleted: "? Следующие объекты будут удалены или останутся без зависимости:"
       are_you_sure_you_want_to_delete_the_object: "Вы уверены, что хотите удалить %{model_name}"
       confirmation: "Да, уверен"
       bulk_delete: "Следующие объекты будут удалены. Это может сломать связи с другими объектами:"


### PR DESCRIPTION
The value does not have question mark at the beginning and also has incomplete translation at the end as [here](https://github.com/airled/rails_admin-i18n/blob/master/locales/en.yml#L129).