### PR TITLE
Fixed RU value for 'flash.error'

### DIFF
--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -44,7 +44,7 @@ ru:
       ago: "назад"
     flash:
       successful: "%{name} успешно %{action}"
-      error: "%{name} не удалось %{action}"
+      error: "%{name} не %{action} из-за ошибок"
       noaction: "Никаких изменений не выполнено"
       model_not_found: "Модель '%{model}' не найдена"
       object_not_found: "Объект %{model} с id '%{id}' не найден"


### PR DESCRIPTION
#28 #59 Fixed value for key `flash.error` (Instead of `не удалось сохранено` it uses `не сохранено из-за ошибок`)