### PR TITLE
minor: adds "last created" table header for German

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -121,6 +121,7 @@ de:
       model_name: Modellname
       records: Datensätze
       username: Anwender
+      last_created: Zuletzt erstellt
     home:
       name: Start
     pagination:


### PR DESCRIPTION
this adds a missing translation for the "Last Created" table header, on the "dashboard"/home page.