### PR TITLE
Complete Ukrainian translations for 1.17.0

### DIFF
--- a/locales/uk-UA.yml
+++ b/locales/uk-UA.yml
@@ -53,6 +53,7 @@ uk-UA:
         title: "Детально про %{model_label} «%{object_label}»"
       show_in_app:
         menu: "Показати у додатку"
+        title: "Показати %{model_label} у додатку"
     export:
       click_to_reverse_selection: "Клік для відміни вибору"
       confirmation: "Експортувати в %{name}"
@@ -61,7 +62,8 @@ uk-UA:
       fields_from: "Поля з %{name}"
       fields_from_associated: "Поля з пов'язаного %{name}"
       options_for: "Опції для %{name}"
-      select: "Веберіть поля для експорту"
+      select: "Виберіть поля для експорту"
+      select_all_fields: "Обрати всі поля"
       csv:
         col_sep: "Роздільник стовпців"
         col_sep_help: "Залишити пустим по замовчуванню ('%{value}')" # value is default_col_sep
@@ -94,6 +96,27 @@ uk-UA:
       save: "Зберегти"
       save_and_add_another: "Зберегти і додати новий елемент"
       save_and_edit: "Зберегти і редагувати"
+    home:
+      name: "Домашня"
+    js:
+      true: Істинно
+      false: Хибно
+      is_present: Наявне
+      is_blank: Порожнє
+      date: Дата ...
+      between_and_: Між ... та ...
+      today: Сьогодні
+      yesterday: Учора
+      this_week: Цього тижня
+      last_week: Попереднього тижня
+      number: Номер ...
+      contains: Містить
+      is_exactly: Саме
+      starts_with: Починається з
+      ends_with: Закінчується на
+      too_many_objects: "Забагато об'єктів, використовуйте вікно пошуку вище"
+      no_objects: "Об'єктів не знайдено"
+    loading: "Завантаження..."
     misc:
       add_filter: "Додати фільтр"
       add_new: "Створити"
@@ -106,14 +129,19 @@ uk-UA:
       filter: "Фільтр"
       filter_date_format: "dd.mm.yy" # a combination of 'dd', 'mm' and 'yy' with any delimiter. No other interpolation will be done!
       log_out: "Розлогінитись"
+      more: "Додатково ще %{count} %{models_name}"
       navigation: "Навігація"
+      navigation_static_label: "Посилання"
       refresh: "Оновити"
       remove: "Видалити"
+      reset_filters: "Скинути фільтри"
       search: "Пошук"
       show_all: "Показати всі"
       up: "Вверх"
-      navigation_static_label: "Посилання"
-      more: "Додатково ще %{count} %{models_name}"
+    pagination:
+      next: "Вперед &raquo;"
+      previous: "&laquo; Назад"
+      truncate: "…"
     table_headers:
       changes: "Зміни"
       created_at: "Дата/Час"
@@ -124,9 +152,4 @@ uk-UA:
       model_name: "Назва моделі"
       records: "Записи"
       username: "Користувач"
-    home:
-      name: "Домашня"
-    pagination:
-      next: "Вперед &raquo;"
-      previous: "&laquo; Назад"
-      truncate: "…"
+    toggle_navigation: "Переключити навігацію"

--- a/locales/uk.yml
+++ b/locales/uk.yml
@@ -7,24 +7,26 @@ uk:
       next: "Вперед &raquo;"
       truncate: "…"
     misc:
-      filter_date_format: "dd.mm.yy" # a combination of 'dd', 'mm' and 'yy' with any delimiter. No other interpolation will be done!
-      search: "Пошук"
-      filter: "Фільтр"
-      refresh: "Оновити"
-      show_all: "Показати всі"
       add_filter: "Додати фільтр"
-      bulk_menu_title: "Вибрані елементи"
-      remove: "Видалити"
       add_new: "Створити"
-      chosen: "Обраний %{name}"
+      ago: "тому"
+      bulk_menu_title: "Вибрані елементи"
       chose_all: "Вибрати всі"
+      chosen: "Обраний %{name}"
       clear_all: "Видалити всі"
-      up: "Вверх"
       down: "Вниз"
+      filter: "Фільтр"
+      filter_date_format: "dd.mm.yy" # a combination of 'dd', 'mm' and 'yy' with any delimiter. No other interpolation will be done!
+      log_out: "Розлогінитись"
+      more: "Більше"
       navigation: "Навігація"
       navigation_static_label: "Посилання"
-      log_out: "Розлогінитись"
-      ago: "тому"
+      refresh: "Оновити"
+      remove: "Видалити"
+      reset_filters: "Скинути фільтри"
+      search: "Пошук"
+      show_all: "Показати всі"
+      up: "Вверх"
     flash:
       successful: "%{name} успішно %{action}"
       error: "%{name} не %{action} через помилки"
@@ -55,6 +57,7 @@ uk:
         menu: "Показати"
         breadcrumb: "%{object_label}"
       show_in_app:
+        title: "Показати %{model_label} у додатку"
         menu: "Показати у додатку"
       new:
         title: "Новий %{model_label}"
@@ -112,7 +115,8 @@ uk:
       new_model: "%{name} (new)"
     export:
       confirmation: "Експортувати в %{name}"
-      select: "Веберіть поля для експорту"
+      select: "Виберіть поля для експорту"
+      select_all_fields: "Обрати всі поля"
       fields_from: "Поля з %{name}"
       fields_from_associated: "Поля з пов'язаного %{name}"
       display: "Показати %{name}: %{type}"
@@ -129,3 +133,23 @@ uk:
         default_col_sep: ","
         col_sep: "Роздільник стовпців"
         col_sep_help: "Залишити пустим по замовчуванню ('%{value}')" # value is default_col_sep
+    js:
+      true: Істинно
+      false: Хибно
+      is_present: Наявне
+      is_blank: Порожнє
+      date: Дата ...
+      between_and_: Між ... та ...
+      today: Сьогодні
+      yesterday: Учора
+      this_week: Цього тижня
+      last_week: Попереднього тижня
+      number: Номер ...
+      contains: Містить
+      is_exactly: Саме
+      starts_with: Починається з
+      ends_with: Закінчується на
+      too_many_objects: "Забагато об'єктів, використовуйте вікно пошуку вище"
+      no_objects: "Об'єктів не знайдено"
+    loading: "Завантаження..."
+    toggle_navigation: "Переключити навігацію"


### PR DESCRIPTION
update uk and uk-UA locales with next strings:
- [x] admin.js.true
- [x] admin.js.false
- [x] admin.js.is_present
- [x] admin.js.is_blank
- [x] admin.js.date
- [x] admin.js.between_and_
- [x] admin.js.today
- [x] admin.js.yesterday
- [x] admin.js.this_week
- [x] admin.js.last_week
- [x] admin.js.number
- [x] admin.js.contains
- [x] admin.js.is_exactly
- [x] admin.js.starts_with
- [x] admin.js.ends_with
- [x] admin.js.too_many_objects
- [x] admin.js.no_objects
- [x] admin.loading
- [x] admin.toggle_navigation
- [x] admin.misc.reset_filters
- [x] admin.misc.more
- [x] admin.actions.show_in_app.title
- [x] admin.export.select_all_fields

## Completeness checks:
```
$ rake i18n-spec:completeness locales/en.yml locales/uk.yml 

### locales/uk.yml

- *COMPLETE* 

$ rake i18n-spec:completeness locales/en.yml locales/uk-UA.yml 

### locales/uk-UA.yml

- *COMPLETE* 
```